### PR TITLE
signaling setup: Use well-known TURN(S)/STUN(S) ports.

### DIFF
--- a/data/signaling/janus.jcfg
+++ b/data/signaling/janus.jcfg
@@ -269,7 +269,7 @@ media: {
 # internal libnice debugging, if needed.
 nat: {
 	stun_server = "<SIGNALING_COTURN_URL>" # HAND-EDIT
-	stun_port = 1271 # HAND-EDIT PORT-EDIT (443)
+	stun_port = 5349 # HAND-EDIT PORT-EDIT (443)
 	nice_debug = false
 	full_trickle = true # HAND-EDIT
 	#ice_nomination = "regular"

--- a/data/signaling/nginx-signaling-upstream-servers.conf
+++ b/data/signaling/nginx-signaling-upstream-servers.conf
@@ -1,3 +1,3 @@
 upstream signaling {
-    server 127.0.0.1:1270; # PORT-EDIT (8080)
+    server 127.0.0.1:3478; # PORT-EDIT (8080)
 }

--- a/data/signaling/signaling-server.conf
+++ b/data/signaling/signaling-server.conf
@@ -1,7 +1,7 @@
 [http]
 # IP and port to listen on for HTTP requests.
 # Comment line to disable the listener.
-listen = 127.0.0.1:1270 # HAND-EDIT PORT-EDIT (8080)
+listen = 127.0.0.1:3478 # HAND-EDIT PORT-EDIT (8080)
 
 # HTTP socket read timeout in seconds.
 #readtimeout = 15

--- a/data/signaling/turnserver.conf
+++ b/data/signaling/turnserver.conf
@@ -27,7 +27,7 @@
 # TLS version 1.0, 1.1 and 1.2.
 # For secure UDP connections, Coturn supports DTLS version 1.
 #
-tls-listening-port=1271
+tls-listening-port=5349
 # PORT-EDIT (5349)
 
 # Alternative listening port for UDP and TCP listeners;

--- a/src/setup-signaling.sh
+++ b/src/setup-signaling.sh
@@ -364,10 +364,10 @@ function signaling_write_secrets_to_file() {
 	echo -e "" >>$1
 	echo -e "Allowed Nextcloud Servers:" >>$1
 	echo -e "$(printf '\t↳ https://%s\n' "${NEXTCLOUD_SERVER_FQDNS[@]}")" >>$1
-	echo -e "STUN server = $SERVER_FQDN:1271" >>$1
+	echo -e "STUN server = $SERVER_FQDN:5349" >>$1
 	echo -e "TURN server:" >>$1
 	echo -e " ↳ 'turn and turns'" >>$1
-	echo -e " ↳ $SERVER_FQDN:1271" >>$1
+	echo -e " ↳ $SERVER_FQDN:5349" >>$1
 	echo -e " ↳ $SIGNALING_TURN_STATIC_AUTH_SECRET" >>$1
 	echo -e " ↳ 'udp & tcp'" >>$1
 	echo -e "High-performance backend:" >>$1
@@ -388,10 +388,10 @@ function signaling_print_info() {
 		"$(printf '\t↳ https://%s\n' "${NEXTCLOUD_SERVER_FQDNS[@]}")\n"
 
 	# Don't actually *log* passwords!
-	log "STUN server = $SERVER_FQDN:1271"
+	log "STUN server = $SERVER_FQDN:5349"
 	log "TURN server:"
 	log " ↳ 'turn and turns'"
-	log " ↳ turnserver+port: $SERVER_FQDN:1271"
+	log " ↳ turnserver+port: $SERVER_FQDN:5349"
 	echo -e " ↳ secret: $SIGNALING_TURN_STATIC_AUTH_SECRET"
 	log " ↳ 'udp & tcp'"
 	log "High-performance backend:"

--- a/src/setup-ufw.sh
+++ b/src/setup-ufw.sh
@@ -54,7 +54,7 @@ function ufw_step2() {
 
 	# Coturn
 	if [ "$SHOULD_INSTALL_SIGNALING" = true ]; then
-		${_cmdprefix}ufw allow 1271 comment "Nextcloud HPB Coturn" | tee -a $LOGFILE_PATH
+		${_cmdprefix}ufw allow 5349 comment "Nextcloud HPB Coturn" | tee -a $LOGFILE_PATH
 		${_cmdprefix}ufw allow 49151:65535/udp comment "Nextcloud HPB Coturn" | tee -a $LOGFILE_PATH
 	fi
 


### PR DESCRIPTION
…e well-known port for the TURN/STUN protocol.

 Fixes: https://github.com/sunweaver/nextcloud-high-performance-backend-setup/issues/21