### PR TITLE
Signaling: Don't enable bullseye-backports for bookworm/sid.

### DIFF
--- a/setup-nextcloud-hpb.sh
+++ b/setup-nextcloud-hpb.sh
@@ -299,7 +299,7 @@ function check_debian_system() {
 
 		# Quick hack for debian testing (currently bookworm)
 		if [[ "$DEBIAN_VERSION" = "bookworm/sid" ]]; then
-			DEBIAN_VERSION="11.3"
+			DEBIAN_VERSION="12"
 		fi
 
 		if ! [[ $DEBIAN_VERSION =~ [0-9] ]]; then

--- a/src/setup-collabora.sh
+++ b/src/setup-collabora.sh
@@ -9,7 +9,6 @@ COLLABORA_KEYRING_DIR="/usr/share/keyrings"
 COLLABORA_KEYRING_FILE="$COLLABORA_KEYRING_DIR/collaboraonline-release-keyring.gpg"
 
 COLLABORA_SOURCES_FILE="/etc/apt/sources.list.d/collaboraonline.sources"
-COLLABORA_REPO_URL="https://www.collaboraoffice.com/repos/CollaboraOnline/CODE-debian$DEBIAN_MAJOR_VERSION"
 
 function install_collabora() {
 	log "Installing Collabora…"
@@ -36,6 +35,15 @@ function collabora_step2() {
 	# 2. Add CODE package repositories
 	log "\nStep 2: Add CODE package repositories"
 
+	collabora_debian_major_version=$DEBIAN_MAJOR_VERSION
+	# Collabora doesn't have a repo for bookworm yet.
+	# FIXME: Remove this hack if Debian Bookworm is released! (or update to Debian 13…)
+	if [ "$collabora_debian_major_version" = "12" ]; then
+		collabora_debian_major_version="11"
+	fi
+	COLLABORA_REPO_URL="https://www.collaboraoffice.com/repos/CollaboraOnline/CODE-debian$collabora_debian_major_version"
+
+	log "Installing Collabora APT-Repo URL: '$COLLABORA_REPO_URL'…"
 	is_dry_run || cat <<EOF >$COLLABORA_SOURCES_FILE
 Types: deb
 URIs: $COLLABORA_REPO_URL


### PR DESCRIPTION

Fixes: #54