### PR TITLE
DHPARAM: Fix DHPARAM file not being generated if signaling-install is disabled.

### DIFF
--- a/setup-nextcloud-hpb.sh
+++ b/setup-nextcloud-hpb.sh
@@ -325,6 +325,27 @@ function log() {
 	echo -e "$@" 2>&1 | tee -a $LOGFILE_PATH
 }
 
+function generate_dhparam_file() {
+	if [ "$BUILT_DHPARAM_FILE" == "true" ]; then
+		# Skip if we already generated dhparam file.
+		return 0
+	fi
+
+	if [ -s "$DHPARAM_PATH" ]; then
+		# Rebuilding dhparam file.
+		log "Removing old dhparam file at '$DHPARAM_PATH'."
+		rm -fv "$DHPARAM_PATH" 2>&1 | tee -a "$LOGFILE_PATH"
+	fi
+
+	log "Generating new dhparam file…"
+	is_dry_run || mkdir -p "$(dirname $DHPARAM_PATH)"
+	is_dry_run || touch "$DHPARAM_PATH"
+	is_dry_run || openssl dhparam -dsaparam -out "$DHPARAM_PATH" 4096
+	is_dry_run || chmod 644 "$DHPARAM_PATH"
+
+	BUILT_DHPARAM_FILE="true"
+}
+
 # Deploys target_file_path to source_file_path while respecting
 # potential custom user config.
 # param 1: source_file_path

--- a/src/setup-certbot.sh
+++ b/src/setup-certbot.sh
@@ -54,6 +54,13 @@ function run_certbot_command() {
 function install_certbot() {
 	log "Installing Certbot…"
 
+	certbot_step1
+	certbot_step2
+
+	log "Certbot install completed."
+}
+
+function certbot_step1() {
 	log "\nStep 1: Installing Certbot packages"
 	packages_to_install=(python3-certbot-nginx certbot ssl-cert)
 	if ! is_dry_run; then
@@ -67,8 +74,12 @@ function install_certbot() {
 	else
 		log "Would have installed '${packages_to_install[@]}' via APT now."
 	fi
+}
 
+function certbot_step2() {
 	log "\nStep 2: Configuring Certbot"
+
+	generate_dhparam_file
 
 	if ! run_certbot_command && ! is_dry_run; then
 		log "Something wen't wrong while starting Certbot."
@@ -93,8 +104,6 @@ function install_certbot() {
 	is_dry_run || chown -R :ssl-cert /etc/letsencrypt/archive
 	is_dry_run || chown -R :ssl-cert /etc/letsencrypt/live
 	is_dry_run || find /etc/letsencrypt/archive -name "privkey*.pem" -exec chmod 640 {} +
-
-	log "Certbot install completed."
 }
 
 # arg: $1 is secret file path

--- a/src/setup-nginx.sh
+++ b/src/setup-nginx.sh
@@ -25,6 +25,9 @@ function nginx_step1() {
 
 function nginx_step2() {
 	log "\nStep 2: Prepare configuration"
+
+	generate_dhparam_file
+
 	include_snippet_signaling_forwarding=""
 	include_snippet_signaling_upstream_servers=""
 	if [ "$SHOULD_INSTALL_SIGNALING" == true ]; then

--- a/src/setup-signaling.sh
+++ b/src/setup-signaling.sh
@@ -265,9 +265,7 @@ function signaling_step4() {
 		is_dry_run || mkdir -p "$COTURN_DIR"
 	fi
 
-	is_dry_run || mkdir -p "$(dirname $DHPARAM_PATH)"
-	is_dry_run || touch "$DHPARAM_PATH"
-	is_dry_run || openssl dhparam -dsaparam -out "$DHPARAM_PATH" 4096
+	generate_dhparam_file
 
 	is_dry_run || chown -R turnserver:turnserver "$COTURN_DIR"
 	is_dry_run || chmod -R 740 "$COTURN_DIR"


### PR DESCRIPTION
The dhparam file is used by nginx and if signaling should not be installed, the dhparam file does not get generated and nginx will inevitable crash. 