### PR TITLE
Fix #196

### DIFF
--- a/src/setup-msmtp.sh
+++ b/src/setup-msmtp.sh
@@ -127,7 +127,7 @@ function msmtp_step3() {
     #log "Replacing '<EMAIL_USER_PASSWORD>' with '$EMAIL_USER_PASSWORD'…"
     log "Replacing '<EMAIL_USER_PASSWORD>…'"
     ESCAPED_EMAIL_USER_PASSWORD=$(printf '%s\n' "$EMAIL_USER_PASSWORD" | sed -e 's/[\/&]/\\&/g')
-    sed -i "s|<EMAIL_USER_PASSWORD>|$ESCAPED_EMAIL_USER_PASSWORD|g" "$TMP_DIR_PATH"/msmtp/*
+    sed -i "s/<EMAIL_USER_PASSWORD>/$ESCAPED_EMAIL_USER_PASSWORD/" "$TMP_DIR_PATH"/msmtp/*
 
     log "Replacing '<EMAIL_SERVER_HOST>' with '$EMAIL_SERVER_HOST'…"
     sed -i "s|<EMAIL_SERVER_HOST>|$EMAIL_SERVER_HOST|g" "$TMP_DIR_PATH"/msmtp/*


### PR DESCRIPTION
ESCAPED_EMAIL_USER_PASSWORD is being escaped for the standard / delimiter, while a | was used. Fixes #196 